### PR TITLE
Set PriceBase as TotalUnpaidBase

### DIFF
--- a/invoice_integration_test.go
+++ b/invoice_integration_test.go
@@ -97,7 +97,7 @@ func TestInvoiceGatewayCRUD(t *testing.T) {
 	// create invoice payment (mark invoice as paid)
 	err = testClient.InvoicePayment().Create(invoice, &InvoicePayment{
 		Price:       invoice.TotalUnpaid,
-		PriceBase:   invoice.TotalUnpaid,
+		PriceBase:   invoice.TotalUnpaidBase,
 		PaymentDate: time.Now().Format("2006-01-02"),
 	})
 	if err != nil {


### PR DESCRIPTION
Fixes issue when currency of Moneybird account differs from currency of invoice. Without this fix, no correct exchange rate is applied.